### PR TITLE
fix(ci): don't trust copy'n'paste

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -135,10 +135,6 @@ jobs:
           type=sha,prefix={{branch}}-
           {{ sha }}
           ${{ inputs.image-tags }}
-        build-args: |
-          BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-          VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
-          REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
 
     -
       name: Build and push Container image


### PR DESCRIPTION
Found in https://github.com/docker/metadata-action#json-output-object and only created problems:

- https://github.com/CirclesUBI/api-server/actions/runs/4140025732
- https://github.com/CirclesUBI/api-server/actions/runs/4140025733